### PR TITLE
single-executable-applications.md - fix Windows injection command

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -105,9 +105,15 @@ tool, [postject][]:
          --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
      ```
 
-   * On Windows:
+   * On Windows - Command Prompt:
      ```console
-     $ npx postject hello.exe NODE_SEA_BLOB sea-prep.blob \
+     $ npx postject hello.exe NODE_SEA_BLOB sea-prep.blob ^
+         --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+     ```
+     
+   * On Windows - PowerShell:
+     ```console
+     $ npx postject hello.exe NODE_SEA_BLOB sea-prep.blob `
          --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
      ```
 


### PR DESCRIPTION
Tested on my windows laptop, it's a shame Command Prompt and PowerShell have different syntax for line-breaks
- and both of them don't work with \ line break